### PR TITLE
Migrate auto scaling launch config to launch template

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -382,21 +382,24 @@ Resources:
     Properties:
       Roles:
         - Ref: WebappRole
-  WebappLaunchConfig:
-    Type: AWS::AutoScaling::LaunchConfiguration
+  WebappLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
     Properties:
-      AssociatePublicIpAddress: true
-      ImageId:
-        Ref: ImageId
-      InstanceType: 
-        Ref: InstanceType
-      SecurityGroups:
-        - Ref: WebappSecurityGroup
-      IamInstanceProfile:
-        Ref: WebappInstanceProfile
-      UserData:
-        "Fn::Base64":
-          !Sub |
+      LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
+      LaunchTemplateData:
+        ImageId:
+          Ref: ImageId
+        InstanceType:
+          Ref: InstanceType
+        SecurityGroupIds:
+          - Ref: WebappSecurityGroup
+        IamInstanceProfile:
+          Arn: !GetAtt
+            - WebappInstanceProfile
+            - Arn
+        UserData:
+          "Fn::Base64":
+            !Sub |
               #!/bin/bash
 
               yum  install -y java-1.8.0-openjdk-devel wget
@@ -468,8 +471,9 @@ Resources:
       DesiredCapacity: !Ref AutoScalingGroupDesiredCapacity
       MinSize: !Ref AutoScalingGroupMinSize
       MaxSize: !Ref AutoScalingGroupMaxSize
-      LaunchConfigurationName:
-        Ref: WebappLaunchConfig
+      LaunchTemplate:
+        LaunchTemplateId: !Ref WebappLaunchTemplate
+        Version: !GetAtt WebappLaunchTemplate.LatestVersionNumber
       VPCZoneIdentifier:
         - Ref: PrivateSubnet1 
         - Ref: PrivateSubnet2 


### PR DESCRIPTION
*Issue #7*

I've replaced the auto scaling launch config with an equivalent launch template by following the [user guide](https://docs.aws.amazon.com/autoscaling/ec2/userguide/migrate-launch-configurations-with-cloudformation.html#update-stack-to-use-launch-template).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
